### PR TITLE
fix: os mocking deleted to fix the setup.test.ts for windows

### DIFF
--- a/__tests__/commands/setup.test.ts
+++ b/__tests__/commands/setup.test.ts
@@ -6,7 +6,6 @@ import accountUtils from '../../src/utils/account';
 import setupUtils from '../../src/utils/setup';
 import { testnetOperatorId, testnetOperatorKey } from '../helpers/state';
 
-jest.mock('os');
 jest.mock('dotenv', () => ({
   __esModule: true,
   config: jest.fn().mockReturnValue({ error: null }),


### PR DESCRIPTION
## Description

This PR addresses the problem described in issue [#7](https://github.com/misiekp/hedera-cli/issues/7) by removing the full `os` mock from the unit test.

### Related Issues

- Closes [#7](https://github.com/misiekp/hedera-cli/issues/7)